### PR TITLE
Redisのキーをクラスメソッドで生成する

### DIFF
--- a/lib/redis/helper.rb
+++ b/lib/redis/helper.rb
@@ -52,6 +52,10 @@ class Redis
         @redis ||= ::Redis.current
       end
 
+      def redis=(conn)
+        @redis = conn
+      end
+
       # 固定キーメソッドを作成する
       # @param [Array<String|Symbol>] names キー名
       # @param [String|Symbol] unique_attr インスタンスの固有キーとして使用するメソッド名

--- a/lib/redis/helper.rb
+++ b/lib/redis/helper.rb
@@ -74,26 +74,30 @@ class Redis
         lock_key = [base_key, LOCK_POSTFIX].compact.join(REDIS_KEY_DELIMITER)
         ::Redis::Helper::Lock.new(redis, lock_key).lock(&block)
       end
+
+      # インスタンス固有キーから#attr_key/#instance_keyが返すキーを生成する
+      # @param [String|Integer] unique_key インスタンス固有のキー
+      # @param [String|Symbol] attr_name attr_key生成時に利用するキー名
+      # @return [String]
+      def generate_key(unique_key, attr_name = nil)
+        [name, unique_key, attr_name].compact.join(REDIS_KEY_DELIMITER)
+      end
     end
 
     # instance固有のkeyとattr_nameからkeyを生成する
     # (instanceに複数のkeyを設定したい場合やkeyにattr_nameを含めたい場合に使用する)
-    # @param [String|Symbol] name キー名
+    # @param [String|Symbol] attr_name キー名
     # @param [String|Symbol] unique_attr インスタンスの固有キーとして使用するメソッド名
     # @return [String]
-    def attr_key(name, unique_attr = nil)
-      [instance_key(unique_attr), name].join(REDIS_KEY_DELIMITER)
+    def attr_key(attr_name, unique_attr = nil)
+      self.class.generate_key(unique_key(unique_attr), attr_name)
     end
 
     # instance固有のkeyを生成する ("<Class Name>:<unique key>")
     # @param [String|Symbol] unique_attr インスタンスの固有キーとして使用するメソッド名
     # @return [String]
     def instance_key(unique_attr = nil)
-      attr_name = unique_attr || DEFAULT_UNIQUE_ATTR_NAME
-      if (unique_key = self.public_send(attr_name)).blank?
-        raise UnknownUniqueValue, "unique keyとして指定された値(#{attr_name})が取得できません"
-      end
-      [self.class.name, unique_key].join(REDIS_KEY_DELIMITER)
+      self.class.generate_key(unique_key(unique_attr))
     end
 
     # 引数で指定した時間にexpireするためのttl値を生成
@@ -127,6 +131,16 @@ class Redis
     # @yield ロック中に実行する処理のブロック
     def lock(base_key, &block)
       self.class.lock(base_key, &block)
+    end
+
+    # インスタンス固有のキーを取得
+    # @param [String|Symbol] unique_attr インスタンスの固有キーとして使用するメソッド名
+    def unique_key(unique_attr = nil)
+      attr_name = unique_attr.presence || DEFAULT_UNIQUE_ATTR_NAME
+      if (unique_key = self.public_send(attr_name)).blank?
+        raise UnknownUniqueValue, "unique keyとして指定された値(#{attr_name})が取得できません"
+      end
+      unique_key
     end
   end
 end

--- a/spec/redis/helper_spec.rb
+++ b/spec/redis/helper_spec.rb
@@ -57,6 +57,23 @@ describe Redis::Helper do
       end
     end
 
+    describe "#instance_key" do
+      context "default unique_attr" do
+        subject { foo.instance_key }
+        it { is_expected.to eq("Foo:42") }
+      end
+
+      context "another unique_attr" do
+        subject { foo.instance_key(:number) }
+        it { is_expected.to eq("Foo:114514") }
+      end
+
+      context "empty unique_attr" do
+        subject { -> { foo.instance_key(:empty_key) } }
+        it { is_expected.to raise_error(Redis::Helper::UnknownUniqueValue) }
+      end
+    end
+
     describe "#ttl_to" do
       subject { foo.ttl_to(to_time, from_time) }
       let(:from_time) { Time.current }
@@ -92,6 +109,16 @@ describe Redis::Helper do
         foo.lock(base_key)
       end
     end
+
+    describe "#unique_key" do
+      it "unique_key with default unique attr name" do
+        expect(foo.unique_key).to eq(42)
+      end
+
+      it "unique_key with specified unique attr name" do
+        expect(foo.unique_key(:number)).to eq(114514)
+      end
+    end
   end
 
   describe ".attr_key" do
@@ -121,6 +148,16 @@ describe Redis::Helper do
       expect(obj = double("Redis::Helper::Lock")).to receive(:lock)
       expect(::Redis::Helper::Lock).to receive(:new).with(Foo.redis, lock_key).and_return(obj)
       Foo.lock(base_key)
+    end
+  end
+
+  describe ".generate_key" do
+    it "generate instance_key" do
+      expect(Foo.generate_key(1)).to eq("Foo:1")
+    end
+
+    it "generate attr_key" do
+      expect(Foo.generate_key(1, :bar)).to eq("Foo:1:bar")
     end
   end
 end

--- a/spec/redis/helper_spec.rb
+++ b/spec/redis/helper_spec.rb
@@ -31,6 +31,15 @@ describe Redis::Helper do
       it("== Redis.current") { is_expected.to eq(Redis.current) }
     end
 
+    describe "#redis=" do
+      before { Foo.redis = double("redis") }
+      after { Foo.redis = nil }
+      subject { foo.redis }
+      it "custom redis connection" do
+        is_expected.not_to eq(Redis.current)
+      end
+    end
+
     describe "#attr_key" do
       context "default unique_attr" do
         subject { foo.attr_key(:bar) }


### PR DESCRIPTION
`id`からinstance_key/attr_keyを取得したいケースが存在するのでキー生成の部分をクラスメソッドに移しました。